### PR TITLE
Fix JSON decoding fallback mechanism

### DIFF
--- a/src/spacetimedb_sdk/protocol.py
+++ b/src/spacetimedb_sdk/protocol.py
@@ -844,12 +844,26 @@ class ProtocolDecoder:
                     message = json_result.sanitized_value
                 except ValidationError as e:
                     raise ValueError(f"JSON validation failed: {e}")
+                except Exception as e:
+                    # Catch any other exceptions from validation and fall back to direct parsing
+                    # This handles cases where validate_json_data might raise unexpected exceptions
+                    try:
+                        message = json.loads(json_str)
+                    except json.JSONDecodeError as json_e:
+                        # If both validation and fallback fail, report the original validation error
+                        raise ValueError(f"JSON validation failed with error: {e}, and fallback parsing also failed: {json_e}")
             else:
                 # Fallback to direct parsing if validation not available
                 message = json.loads(json_str)
                 
         except (json.JSONDecodeError, UnicodeDecodeError) as e:
             raise ValueError(f"Failed to decode JSON message: {e}")
+        except ValueError:
+            # Re-raise ValueError exceptions (these are our custom validation errors)
+            raise
+        except Exception as e:
+            # Catch any other unexpected exceptions and provide a meaningful error
+            raise ValueError(f"Unexpected error during JSON message decoding: {e}")
         
         # Check for legacy identity format first
         if "__identity__" in message:

--- a/src/spacetimedb_sdk/websocket_client.py
+++ b/src/spacetimedb_sdk/websocket_client.py
@@ -67,17 +67,33 @@ from .memory_management import (
     BoundedDict, BoundedSubscriptionManager, RecursionLimiter,
     MemoryAccountant, MessageSizeValidator, get_global_memory_accountant
 )
-from .validation import (
-    get_security_manager,
-    validate_url,
-    validate_websocket_url,
-    validate_sql_query,
-    validate_json_data,
-    sanitize_url,
-    sanitize_sql_query,
-    sanitize_json_data,
-    ValidationError
-)
+# Import validation with fallback handling
+try:
+    from .validation import (
+        get_security_manager,
+        validate_url,
+        validate_websocket_url,
+        validate_sql_query,
+        validate_json_data,
+        sanitize_url,
+        sanitize_sql_query,
+        sanitize_json_data,
+        ValidationError
+    )
+except ImportError:
+    # Fallback if validation module is not available
+    validate_json_data = None
+    ValidationError = Exception
+    
+    # Define minimal fallback functions - these won't be used in normal operation
+    # but prevent ImportError when validation module is unavailable
+    get_security_manager = lambda: None
+    validate_url = lambda url: True
+    validate_websocket_url = lambda url: True
+    validate_sql_query = lambda query: True
+    sanitize_url = lambda url: url
+    sanitize_sql_query = lambda query: query
+    sanitize_json_data = lambda data: data
 
 
 class SubscriptionMetrics:
@@ -1050,19 +1066,26 @@ class ModernWebSocketClient:
                 # Check if this is a JSON message received when binary protocol is expected
                 if frame_type == "TEXT" and self.use_binary:
                     try:
-                        # Validate JSON message for security before parsing
-                        json_result = validate_json_data(message, "websocket_message")
-                        if json_result.is_valid:
-                            json_data = json_result.sanitized_value
+                        # Validate JSON message for security before parsing if validation is available
+                        if validate_json_data:
+                            json_result = validate_json_data(message, "websocket_message")
+                            if json_result.is_valid:
+                                json_data = json_result.sanitized_value
+                                message_types = list(json_data.keys()) if isinstance(json_data, dict) else []
+                                self.logger.warning(f"Unknown message type in data: {message_types}")
+                                
+                                # Log specific message types that are commonly mismatched
+                                for msg_type in ['IdentityToken', 'InitialSubscription', 'TransactionUpdate']:
+                                    if isinstance(json_data, dict) and msg_type in json_data:
+                                        self.logger.warning(f"Unknown message type in data: {{'{msg_type}': {{...}}}}")
+                            else:
+                                self.logger.warning(f"Invalid JSON message: {'; '.join(str(e) for e in json_result.errors)}")
+                        else:
+                            # Fallback to direct parsing if validation not available
+                            import json
+                            json_data = json.loads(message)
                             message_types = list(json_data.keys()) if isinstance(json_data, dict) else []
                             self.logger.warning(f"Unknown message type in data: {message_types}")
-                            
-                            # Log specific message types that are commonly mismatched
-                            for msg_type in ['IdentityToken', 'InitialSubscription', 'TransactionUpdate']:
-                                if isinstance(json_data, dict) and msg_type in json_data:
-                                    self.logger.warning(f"Unknown message type in data: {{'{msg_type}': {{...}}}}")
-                        else:
-                            self.logger.warning(f"Invalid JSON message: {'; '.join(str(e) for e in json_result.errors)}")
                     except ValidationError as e:
                         self.logger.warning(f"JSON validation failed: {e}")
                     except Exception as e:


### PR DESCRIPTION
## Description of Changes
*   **Fixes `TypeError` when `validation` module is unavailable:** Previously, the SDK would crash if the optional `validation` module was not installed, due to `validate_json_data` being called when it was `None`.
*   **Ensures graceful fallback:** Implemented `try...except ImportError` for validation module imports in `websocket_client.py` and added a null check (`if validate_json_data:`) before calling the function. This ensures the SDK falls back to direct `json.loads()` when validation is not present.
*   **Enhances JSON decoding robustness:** Improved exception handling in `protocol.py`'s `_decode_json` method to better manage unexpected errors during validation or parsing, ensuring a more resilient fallback mechanism.

## API

 - [ ] This is an API breaking change to the SDK

## Requires SpacetimeDB PRs
None