### PR TITLE
Fix overflow error in connection_id conversion

### DIFF
--- a/src/spacetimedb_sdk/protocol.py
+++ b/src/spacetimedb_sdk/protocol.py
@@ -877,9 +877,15 @@ class ProtocolDecoder:
             # Handle connection_id which might be a number or hex string
             conn_id_data = message.get("__connection_id__", 0)
             if isinstance(conn_id_data, int):
-                # Convert integer to 16-byte representation
-                conn_id_bytes = conn_id_data.to_bytes(16, byteorder='big')
-                connection_id = ConnectionId(data=conn_id_bytes)
+                # Safe parsing: check if integer fits in 16 bytes
+                try:
+                    if conn_id_data < 0 or conn_id_data >= (1 << 128):
+                        raise OverflowError("Integer too large for 16-byte representation")
+                    conn_id_bytes = conn_id_data.to_bytes(16, byteorder='big')
+                    connection_id = ConnectionId(data=conn_id_bytes)
+                except (OverflowError, ValueError):
+                    # Fallback for invalid integer values
+                    connection_id = ConnectionId(data=b"\x00" * 16)
             elif isinstance(conn_id_data, str):
                 try:
                     if conn_id_data.startswith("0x"):


### PR DESCRIPTION
```
## Description of Changes
*   **Bug Fix**: Addressed an `OverflowError` in `src/spacetimedb_sdk/protocol.py` when parsing `connection_id` from legacy `__identity__` messages.
*   **Improved Robustness**: The `connection_id` integer-to-bytes conversion now includes overflow and value validation, preventing crashes for excessively large or invalid integer inputs.
*   **Consistent Handling**: Aligns `connection_id` parsing with existing robust error handling patterns within the SDK, falling back to a default value (16 zero bytes) on error.

## API

 - [ ] This is an API breaking change to the SDK

## Requires SpacetimeDB PRs
*None*
```