### PR TITLE
Handle subscription method error checking

### DIFF
--- a/src/spacetimedb_sdk/memory_management.py
+++ b/src/spacetimedb_sdk/memory_management.py
@@ -194,8 +194,12 @@ class BoundedDict(Generic[K, V]):
                 return self._data[key]
             return default
     
-    def set(self, key: K, value: V) -> None:
-        """Set an item in the dictionary."""
+    def set(self, key: K, value: V) -> bool:
+        """Set an item in the dictionary.
+        
+        Returns:
+            bool: True if the item was successfully set, False if operation failed
+        """
         with self._lock:
             # Calculate size
             size = self._estimate_size(value)
@@ -204,7 +208,7 @@ class BoundedDict(Generic[K, V]):
             if self._memory_accountant:
                 if not self._memory_accountant.try_allocate('cache', size):
                     logger.warning(f"Memory allocation failed for cache item {key} ({size} bytes)")
-                    return
+                    return False
             
             # Remove old value if exists
             if key in self._data:
@@ -219,6 +223,7 @@ class BoundedDict(Generic[K, V]):
             self._data[key] = value
             self._size_cache[key] = size
             self._eviction_policy.on_access(key)
+            return True
     
     def delete(self, key: K) -> bool:
         """Delete an item from the dictionary."""

--- a/src/spacetimedb_sdk/websocket_client.py
+++ b/src/spacetimedb_sdk/websocket_client.py
@@ -643,7 +643,11 @@ class ModernWebSocketClient:
                     raise ValidationError(f"Invalid connection URL: {'; '.join(str(e) for e in url_result.errors)}")
                 url = url_result.sanitized_value
             except ValidationError as e:
-                raise WebSocketHandshakeError(f"Invalid connection URL: {e}")
+                raise WebSocketHandshakeError(
+                    status_code=400,
+                    status_message=f"Invalid connection URL: {e}",
+                    url=url
+                )
             
             # Store URL for error diagnostics
             self.connection_url = url
@@ -906,8 +910,12 @@ class ModernWebSocketClient:
         query_id = QueryId.generate()
         
         with self._lock:
-            self.active_subscriptions.set(request_id, query_id)
-            self.subscription_queries.set(query_id, [query])
+            if not self.active_subscriptions.set(request_id, query_id):
+                raise RuntimeError(f"Failed to store subscription for request_id {request_id}")
+            if not self.subscription_queries.set(query_id, [query]):
+                # Clean up the partial state
+                self.active_subscriptions.delete(request_id)
+                raise RuntimeError(f"Failed to store subscription query for query_id {query_id}")
         
         message = SubscribeSingleMessage(
             query=query,
@@ -923,8 +931,12 @@ class ModernWebSocketClient:
         query_id = QueryId.generate()
         
         with self._lock:
-            self.active_subscriptions.set(request_id, query_id)
-            self.subscription_queries.set(query_id, queries)
+            if not self.active_subscriptions.set(request_id, query_id):
+                raise RuntimeError(f"Failed to store subscription for request_id {request_id}")
+            if not self.subscription_queries.set(query_id, queries):
+                # Clean up the partial state
+                self.active_subscriptions.delete(request_id)
+                raise RuntimeError(f"Failed to store subscription queries for query_id {query_id}")
         
         message = SubscribeMultiMessage(
             query_strings=queries,
@@ -1609,12 +1621,3 @@ class ModernWebSocketClient:
     def reset_subscription_metrics(self) -> None:
         """Reset all subscription health metrics."""
         self.subscription_metrics.reset_metrics()
-    
-    def get_protocol_helper(self):
-        """Get the protocol helper for client-side encoding compatibility."""
-        return {
-            'encoder': self.encoder,
-            'decoder': self.decoder,
-            'use_binary': self.use_binary,
-            'protocol': self.protocol
-        }


### PR DESCRIPTION
## Description of Changes
*   **Bug Fix:** Prevents `subscribe_single` and `subscribe_multi` from entering an inconsistent state when internal subscription storage (via `BoundedDict`) silently fails.
*   **Improved Robustness:** `BoundedDict.set()` now returns a boolean indicating success, allowing subscription methods to detect and handle storage failures by raising a `RuntimeError` and cleaning up partial state.
*   **Minor Fixes:** Corrected `WebSocketHandshakeError` instantiation and removed a redundant internal method.

## API

 - [ ] This is an API breaking change to the SDK

*The return type of `BoundedDict.set()` changed from `None` to `bool`. As `BoundedDict` is an internal utility, this is not considered a public SDK API breaking change.*

## Requires SpacetimeDB PRs
*None*