### PR TITLE
Rename custom deprecation warning class

### DIFF
--- a/tests/refactoring/src/spacetimedb_sdk/events/legacy_compat.py
+++ b/tests/refactoring/src/spacetimedb_sdk/events/legacy_compat.py
@@ -17,7 +17,7 @@ from .core_events import EventType, EventContext
 from .event_manager import UnifiedEventManager, EventManagerConfig
 
 
-class DeprecationWarning(UserWarning):
+class LegacyDeprecationWarning(UserWarning):
     """Warning for deprecated event system usage."""
     pass
 
@@ -30,7 +30,7 @@ def deprecated(alternative: str = None):
             message = f"{func.__name__} is deprecated"
             if alternative:
                 message += f". Use {alternative} instead"
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
+            warnings.warn(message, LegacyDeprecationWarning, stacklevel=2)
             return func(*args, **kwargs)
         return wrapper
     return decorator
@@ -543,9 +543,9 @@ def get_global_compatibility_layer() -> CompatibilityLayer:
 def enable_legacy_warnings(enabled: bool = True):
     """Enable or disable legacy system warnings."""
     if enabled:
-        warnings.filterwarnings("default", category=DeprecationWarning)
+        warnings.filterwarnings("default", category=LegacyDeprecationWarning)
     else:
-        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        warnings.filterwarnings("ignore", category=LegacyDeprecationWarning)
 
 
 def get_migration_guide() -> str:


### PR DESCRIPTION
## Description of Changes
*   **Bug Fix**: Renamed the custom `DeprecationWarning` class to `LegacyDeprecationWarning` in `legacy_compat.py`. This resolves an issue where the custom class shadowed Python's built-in `DeprecationWarning`, preventing potential conflicts and unexpected behavior. All internal references to the class were updated accordingly.

## API

 - [ ] This is an API breaking change to the SDK

## Requires SpacetimeDB PRs
*None*