### PR TITLE
Fix unreachable condition in HandlerInfo

### DIFF
--- a/tests/refactoring/src/spacetimedb_sdk/events/core_events.py
+++ b/tests/refactoring/src/spacetimedb_sdk/events/core_events.py
@@ -199,8 +199,8 @@ class HandlerInfo:
     """Information about a registered event handler."""
     handler: UniversalEventHandler
     priority: EventPriority
-    is_async: bool
     registration_time: float
+    is_async: Optional[bool] = None
     call_count: int = 0
     total_duration: float = 0.0
     last_error: Optional[Exception] = None


### PR DESCRIPTION
```
## Description of Changes
Fixes a bug in `HandlerInfo` where the `is_async` field was typed as `bool`, making the `if self.is_async is None:` check in `__post_init__` unreachable. This prevented the intended auto-detection of asynchronous event handlers.

The `is_async` field is now `Optional[bool] = None`. This change enables the `__post_init__` method to correctly auto-detect if a handler is async when `is_async` is not explicitly provided, while still allowing explicit control. Dataclass field order was also adjusted for correctness.

## API

 - [ ] This is an API breaking change to the SDK


## Requires SpacetimeDB PRs
None
```