### PR TITLE
Fix mutable default values in validation result

### DIFF
--- a/src/spacetimedb_sdk/validation/validators.py
+++ b/src/spacetimedb_sdk/validation/validators.py
@@ -9,6 +9,9 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Union, NamedTuple
 from dataclasses import dataclass, field
 import logging
+import re
+import time
+from functools import wraps
 
 logger = logging.getLogger(__name__)
 
@@ -28,17 +31,19 @@ class ValidationError(Exception):
         return f"Validation error: {self.message}"
 
 
-class ValidationResult(NamedTuple):
+@dataclass
+class ValidationResult:
     """Result of a validation operation."""
     is_valid: bool
     sanitized_value: Any = None
-    errors: List[ValidationError] = []
-    warnings: List[str] = []
+    errors: List[ValidationError] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
     
     @property
     def value(self) -> Any:
         """Get the sanitized value or original value if validation failed."""
         return self.sanitized_value if self.is_valid else None
+
 
 
 @dataclass
@@ -249,7 +254,6 @@ class RegexValidator(Validator):
     
     def __init__(self, pattern: str, config: Optional[ValidationConfig] = None):
         super().__init__(config)
-        import re
         self.pattern = pattern
         self.regex = re.compile(pattern)
     


### PR DESCRIPTION
## Description of Changes
*   **Bug Fix**: Addressed a classic Python bug where `ValidationResult` instances shared mutable default lists for `errors` and `warnings`, leading to potential data corruption.
*   **Implementation**: Converted `ValidationResult` from a `NamedTuple` to a `dataclass` and utilized `field(default_factory=list)` to ensure each instance has its own independent list objects for `errors` and `warnings`.

## API

 - [ ] This is an API breaking change to the SDK